### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-#Snowflake.Net
+# Snowflake.Net
 
 A port of  Twitter's [Snowflake](https://github.com/twitter/snowflake)  algorithm to C#.
 
 Snowflake is a service for generating unique ID numbers at high scale.
 
-###License
+### License
 Apache 2.0


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
